### PR TITLE
Pass along verify as validate_cert

### DIFF
--- a/trequests/__init__.py
+++ b/trequests/__init__.py
@@ -38,7 +38,8 @@ class AsyncHTTPAdapter(requests.adapters.HTTPAdapter):
         resp = asyncify(http_client.fetch)(request=request.url,
                                            method=request.method,
                                            body=request.body,
-                                           headers=request.headers)
+                                           headers=request.headers,
+                                           validate_cert=verify)
 
         # We probably don't get this from any of the tornado adaptors, so
         # we stub it out as Unknown


### PR DESCRIPTION
When using SSL and passing requests' `verify=False`, this will pass it along to the the async HTTPRequest object.